### PR TITLE
Fix "az group exists" check to use tsv output

### DIFF
--- a/Mona.SaaS/Mona.SaaS.Setup/basic-deploy.sh
+++ b/Mona.SaaS/Mona.SaaS.Setup/basic-deploy.sh
@@ -207,7 +207,7 @@ fi
 # Create the resource group if it doesn't already exist.
 # If it already exists confirm that it's empty.
 
-if [[ $(az group exists --resource-group "$resource_group_name") -eq false ]]; then
+if [[ $(az group exists --resource-group "$resource_group_name" --output tsv) -eq false ]]; then
     echo "$lp Creating resource group [$resource_group_name]..."
     az group create --location "$deployment_region" --name "$resource_group_name"
 


### PR DESCRIPTION
Added "--output tsv" to "az group exists" check because if default "az config" is table or JSON, then "az group exists" always returned false (since it was not matching the string "false") and basic-deploy.sh failed to create the resource group and all subsequent resources. (Same fix as in PR #1)