### PR TITLE
Added 'event-store' storage container to bicep template

### DIFF
--- a/Mona.SaaS/Mona.SaaS.Setup/templates/mona_and_turnstile.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/templates/mona_and_turnstile.bicep
@@ -50,6 +50,7 @@ var monaWebAppName = 'mona-web-${cleanDeploymentName}'
 
 // For Turnstile-specific resources
 
+var turnEventStoreContainerName = 'event-store'
 var turnConfigContainerName = 'turn-configuration'
 var turnConfigBlobName = 'publisher_config.json'
 var turnCosmosDbAccountName = 'turn-cosmos-${cleanDeploymentName}'
@@ -140,6 +141,10 @@ resource monaTestSubStorageContainer 'Microsoft.Storage/storageAccounts/blobServ
 
 resource monaStageSubStorageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-09-01' = {
   name: '${storageAccount.name}/default/${monaStageSubContainerName}'
+}
+
+resource turnEventStoreStorageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-09-01' = {
+  name: '${storageAccount.name}/default/${turnEventStoreContainerName}'
 }
 
 resource storageAccountPolicies 'Microsoft.Storage/storageAccounts/managementPolicies@2019-06-01' = {


### PR DESCRIPTION
This might trip someone else up later. A function (`PostEventToStore`) populates this container with events published to Turnstile's event grid topic. BUT, it's mainly here to support `../tests/e2e.sh` which verifies certain events as part of an automated e2e testing script. __It is not hooked up to Event Grid by default.__ 

Note to self -- create a template.
