### PR TITLE
Deploy fails without properties for server farm

### DIFF
--- a/Mona.SaaS/Mona.SaaS.Setup/templates/basic-deploy.json
+++ b/Mona.SaaS/Mona.SaaS.Setup/templates/basic-deploy.json
@@ -241,7 +241,9 @@
                 "family": "S",
                 "capacity": 1
             },
-            "kind": "app"
+            "kind": "app",
+			"properties": {
+            }
         },
         {
             "type": "Microsoft.Web/sites",


### PR DESCRIPTION
template
Hi Guys,

When running the basic-deploy.sh the script fails on the Deploying Mona to subscription step, see below:

{"code": "InvalidTemplateDeployment", "message": "The template deployment 'mona-deploy-wpmona' is not valid according to the validation procedure. The tracking id is 'xxx'. See inner errors for details."}

Inner Errors: 
{"message": "Object reference not set to an instance of an object."}

This is because the ARM template is missing the properties for the Microsoft.Web/serverfarms. I have added an empty properties property and now the template deploys. This seems to have been changed recently in Azure.

Cheers,

Ron