### PR TITLE
Check account type when running basic-deploy

### DIFF
--- a/Mona.SaaS/Mona.SaaS.Setup/basic-deploy.sh
+++ b/Mona.SaaS/Mona.SaaS.Setup/basic-deploy.sh
@@ -69,14 +69,14 @@ check_account_type() {
   user_type=$(curl --location --request GET 'https://graph.microsoft.com/v1.0/me?$select=userType' -H "Content-Type: application/json" -H "Authorization: Bearer $graph_token" --no-progress-meter | jq -r ".userType");
 
   if [ "$user_type" = "Guest" ]; then
-      echo "$lp ❌   Guest account will not work"
+      echo "$lp ❌   Mona cannot be installed using a Guest account. Please use Workplace or School account with type Member."
       return 1
   fi
   
   is_msa=$(curl --location --request GET 'https://graph.microsoft.com/v1.0/me?$select=identities' -H "Content-Type: application/json" -H "Authorization: Bearer $graph_token" --no-progress-meter | jq -r '.identities | map(. | select(.issuer=="MicrosoftAccount")) | . | length > 0');
 
   if [ "$is_msa" = "true" ]; then
-    echo "$lp ❌   Microsoft Account (personal accounts) is not supported."
+    echo "$lp ❌   Mona cannot be installed using a personal Microsoft account. Please use Workplace or School account with type Member."
     return 1
   fi
 }

--- a/Mona.SaaS/Mona.SaaS.Setup/basic-deploy.sh
+++ b/Mona.SaaS/Mona.SaaS.Setup/basic-deploy.sh
@@ -75,7 +75,7 @@ check_account_type() {
   
   is_msa=$(curl --location --request GET 'https://graph.microsoft.com/v1.0/me?$select=identities' -H "Content-Type: application/json" -H "Authorization: Bearer $graph_token" --no-progress-meter | jq -r '.identities | map(. | select(.issuer=="MicrosoftAccount")) | . | length > 0');
 
-  if [ $is_msa ]; then
+  if [ "$is_msa" = "true" ]; then
     echo "$lp ❌   Microsoft Account (personal accounts) is not supported."
     return 1
   fi

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ First, ensure that the following prerequisites are met.
  * You have an active Azure subscription. [If you don't already have one, get one free here](https://azure.microsoft.com/free).
  * You have the ability to create new app registrations within your Azure Active Directory (AAD) tenant. In order to create app registrations, you must be a directory administrator. For more information, see [this article](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference).
  * You have the ability to create resources and resource groups within the target Azure subscription. Typically, this requires at least [contributor-level access](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor) to the subscription.
+ * You have a Workplace or School account. Guest account or personal accounts will not work.
 
  ### 2. Clone the Mona SaaS GitHub repository
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 * [How do I uninstall Mona?](#how-do-i-uninstall-mona)
 * [Where is the admin center?](#where-is-the-admin-center)
 * [How can I return to the setup wizard?](#how-can-i-return-to-the-setup-wizard)
+* [Why do I get Access Denied in setup wizard?](#why-do-i-get-access-denied-in-setup-wizard)
 * [Where can I find my offer's Partner Center technical configuration details?](#where-can-i-find-my-offers-partner-center-technical-configuration-details)
 * [Where can I learn more about the various events that Mona publishes?](#where-can-i-learn-more-about-the-various-events-that-mona-publishes)
 * [Can I handle subscription events somewhere other than Logic Apps?](#can-i-handle-subscription-events-somewhere-other-than-logic-apps)
@@ -55,6 +56,11 @@ In your browser, navigate to `/admin` (e.g., `https://mona-web-***.azurewebsites
 ## How can I return to the setup wizard?
 
 In your browser, navigate to `/setup` (e.g., `https://mona-web-***.azurewebsites.net/setup`).
+
+## Why do I get Access Denied in setup wizard?
+
+If you installed Mona with a Guest account or a Personal account (Microsoft Account) you will get an Access Denied error when accessing
+the setup wizard or admin center. 
 
 ## Where can I find my offer's Partner Center technical configuration details?
 


### PR DESCRIPTION
Adds check for account types when running basic-deploy.sh. The install script will not run if account is:
* Guest account
* Personal Microsoft account

This will hopefully avoid confusion for users and will "solve" this issue:
https://github.com/microsoft/mona-saas/issues/86
