### PR TITLE
In "Supporting Resources", removed "Basic Integration"

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ Since Mona SaaS is deployed into your Azure environment, the only costs that you
     * Note that you can deploy Mona SaaS to an existing Windows-based App Service Plan using the [`-a` setup script parameter](#setup-script-parameters).
 * An [Event Grid topic](https://docs.microsoft.com/azure/event-grid/custom-topics) ([Pricing](https://azure.microsoft.com/pricing/details/event-grid/))
 * Six (6) independent [Azure Logic Apps](https://docs.microsoft.com/azure/logic-apps/logic-apps-overview) preconfigured to handle different types of Marketplace events (Consumption Plan | [Pricing](https://azure.microsoft.com/pricing/details/logic-apps/))
-* A Basic [Integration Account](https://docs.microsoft.com/azure/logic-apps/logic-apps-enterprise-integration-create-integration-account?tabs=azure-portal) ([Pricing](https://azure.microsoft.com/pricing/details/logic-apps/))
 * A [locally-redundant (LRS)](https://docs.microsoft.com/azure/storage/common/storage-redundancy#locally-redundant-storage) standard (GPv2) [storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) ([Pricing](https://azure.microsoft.com/pricing/details/storage/blobs/))
 * [Application Insights](https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) ([Pricing](https://docs.microsoft.com/azure/azure-monitor/app/pricing))
 


### PR DESCRIPTION
In "Supporting Resources", removed "Basic Integration" services as it is no longer part of the architecture.