### PR TITLE
Fix for null beneficiary/purchaser puid

### DIFF
--- a/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_canceled_workflow.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_canceled_workflow.bicep
@@ -132,7 +132,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Beneficiary User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Is Free Trial Subscription?': {
                   type: 'boolean'
@@ -156,7 +156,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Purchaser User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Subscription End Date': {
                   type: ['string', 'null'] 

--- a/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_plan_changed_workflow.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_plan_changed_workflow.bicep
@@ -137,7 +137,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Beneficiary User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Is Free Trial Subscription?': {
                   type: 'boolean'
@@ -161,7 +161,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Purchaser User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Subscription End Date': {
                   type: ['string', 'null'] 

--- a/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_purchased_workflow.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_purchased_workflow.bicep
@@ -132,7 +132,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Beneficiary User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Is Free Trial Subscription?': {
                   type: 'boolean'
@@ -156,7 +156,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Purchaser User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Subscription End Date': {
                   type: ['string', 'null'] 

--- a/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_reinstated_workflow.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_reinstated_workflow.bicep
@@ -132,7 +132,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Beneficiary User ID': {
-                  type: 'string'
+                 type: ['string', 'null']
                 }
                 'Is Free Trial Subscription?': {
                   type: 'boolean'
@@ -156,7 +156,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Purchaser User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Subscription End Date': {
                   type: ['string', 'null'] 

--- a/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_renewed_workflow.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_renewed_workflow.bicep
@@ -130,7 +130,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Beneficiary User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Is Free Trial Subscription?': {
                   type: 'boolean'
@@ -154,7 +154,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Purchaser User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Subscription End Date': {
                   type: ['string', 'null'] 

--- a/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_seat_qty_changed_workflow.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_seat_qty_changed_workflow.bicep
@@ -135,7 +135,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Beneficiary User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Is Free Trial Subscription?': {
                   type: 'boolean'
@@ -159,7 +159,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Purchaser User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Subscription End Date': {
                   type: ['string', 'null'] 

--- a/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_suspended_workflow.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/integration_packs/default/on_suspended_workflow.bicep
@@ -130,7 +130,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Beneficiary User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Is Free Trial Subscription?': {
                   type: 'boolean'
@@ -154,7 +154,7 @@ resource workflow 'Microsoft.Logic/workflows@2019-05-01' = {
                   type: 'string'
                 }
                 'Purchaser User ID': {
-                  type: 'string'
+                  type: ['string', 'null']
                 }
                 'Subscription End Date': {
                   type: ['string', 'null'] 


### PR DESCRIPTION
Corrected Logic App templates to accept `null` for beneficiary/purchaser `puid`