### PR TITLE
Enforce TLS 1.2 for storage accounts

### DIFF
--- a/Mona.SaaS/Mona.SaaS.Setup/templates/basic_deploy.bicep
+++ b/Mona.SaaS/Mona.SaaS.Setup/templates/basic_deploy.bicep
@@ -98,6 +98,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   properties: {
     accessTier: 'Hot'
     supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
     allowBlobPublicAccess: false
     allowSharedKeyAccess: false
   }


### PR DESCRIPTION
Sets minimumTlsVersion to TLS1_2 in the storage account template to align with Microsoft’s TLS 1.2+ requirement after Feb 2026.